### PR TITLE
Add IEnumerable.Choose(), house-keeping, multi-target

### DIFF
--- a/Base.Tests/Base.Tests.csproj
+++ b/Base.Tests/Base.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
         <PackageReference Include="coverlet.collector" Version="3.2.0">

--- a/Base/Base.csproj
+++ b/Base/Base.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>net6.0</TargetFramework>
-      <ImplicitUsings>enable</ImplicitUsings>
+      <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
+      <LangVersion>10</LangVersion>
+      <ImplicitUsings>disable</ImplicitUsings>
       <Nullable>enable</Nullable>
       <RootNamespace>FruityFoundation.Base</RootNamespace>
       <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -15,7 +16,6 @@
       <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
       <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>

--- a/Base/Extensions/DataReaderExtensions.cs
+++ b/Base/Extensions/DataReaderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Data;
+﻿using System;
+using System.Data;
 using FruityFoundation.Base.Structures;
 
 namespace FruityFoundation.Base.Extensions;

--- a/Base/Extensions/EnumerableExtensions.cs
+++ b/Base/Extensions/EnumerableExtensions.cs
@@ -8,7 +8,13 @@ public static class EnumerableExtensions
 {
 	public static IEnumerable<T> ConditionalConcat<T>(this IEnumerable<T> enumerable, bool isConditionValid, IEnumerable<T> second) =>
 		!isConditionValid ? enumerable : enumerable.Concat(second);
-	
+
 	public static IEnumerable<T> ConditionalWhere<T>(this IEnumerable<T> enumerable, bool isConditionValid, Func<T, bool> pred) =>
 		!isConditionValid ? enumerable : enumerable.Where(pred);
+
+	public static IEnumerable<TOutput> Choose<TInput, TOutput>(this IEnumerable<TInput> enumerable, Func<TInput, TOutput?> mapper) =>
+		enumerable
+			.Select(mapper)
+			.Where(x => x is not null)
+			.Cast<TOutput>();
 }

--- a/Base/Extensions/EnumerableExtensions.cs
+++ b/Base/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,8 @@
-﻿namespace FruityFoundation.Base.Extensions;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FruityFoundation.Base.Extensions;
 
 public static class EnumerableExtensions
 {

--- a/Base/Extensions/StringExtensions.cs
+++ b/Base/Extensions/StringExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace FruityFoundation.Base.Extensions;
+﻿using System;
+
+namespace FruityFoundation.Base.Extensions;
 
 public static class StringExtensions
 {
@@ -14,5 +16,5 @@ public static class StringExtensions
 	/// <param name="str"></param>
 	/// <param name="maxLength">The maximum number of characters. If <paramref name="str"/> has fewer characters, it will be truncated to the length of <paramref name="str"/>.</param>
 	public static string Truncate(this string str, int maxLength) =>
-		str[..Math.Min(str.Length, maxLength)];
+		str.Substring(0, Math.Min(str.Length, maxLength));
 }

--- a/Base/Structures/Maybe.cs
+++ b/Base/Structures/Maybe.cs
@@ -1,5 +1,8 @@
 ﻿// Normally we wouldn't want to disable Nullable references, but in this case we want to.
 // We're assuming that if you're following Maybe conventions, you won't be hitting null ref exceptions.
+
+using System;
+
 #pragma warning disable CS8601
 namespace FruityFoundation.Base.Structures;
 

--- a/Base/Structures/MaybeExtensions.cs
+++ b/Base/Structures/MaybeExtensions.cs
@@ -1,4 +1,7 @@
-﻿namespace FruityFoundation.Base.Structures;
+﻿using System;
+using System.Collections.Generic;
+
+namespace FruityFoundation.Base.Structures;
 
 public static class MaybeExtensions
 {

--- a/Base/Structures/MaybeExtensions.cs
+++ b/Base/Structures/MaybeExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FruityFoundation.Base.Structures;
 
@@ -23,4 +24,10 @@ public static class MaybeExtensions
 
 	public static T? ToNullable<T>(this Maybe<T> item) where T : struct =>
 		item.HasValue ? item.Value : null;
+
+	public static IEnumerable<TOutput> Choose<TInput, TOutput>(this IEnumerable<TInput> enumerable, Func<TInput, Maybe<TOutput>> mapper) =>
+		enumerable
+			.Select(mapper)
+			.Where(x => x.HasValue)
+			.Select(x => x.Value);
 }

--- a/Base/Structures/OneOf.cs
+++ b/Base/Structures/OneOf.cs
@@ -1,4 +1,6 @@
-﻿namespace FruityFoundation.Base.Structures;
+﻿using System;
+
+namespace FruityFoundation.Base.Structures;
 
 public class OneOf<T1, T2>
 {

--- a/FsBase/Extensions.fs
+++ b/FsBase/Extensions.fs
@@ -1,16 +1,11 @@
 ﻿namespace FruityFoundation.FsBase
-
-open System.Runtime.CompilerServices
 open FruityFoundation.Base.Structures
 
-[<Extension>]
-type Extensions () =
-    [<Extension>]
-    static member ToMaybe (opt : 'a option) =
-        match opt with
+module Option =
+    let toMaybe : 'a option -> Maybe<'a> = function
         | Some x -> x |> Maybe.Create
         | None -> Maybe.Empty ()
 
-    [<Extension>]
-    static member ToFSharpOption (opt : 'a Maybe) =
-        if opt.HasValue then Some opt.Value else None
+    let fromMaybe : Maybe<'a> -> 'a option = function
+        | x when x.HasValue -> Some x.Value
+        | _ -> None


### PR DESCRIPTION
- chore: dual-target Base to .NET Standard 2.0
- feat: add IEnumerable<T>.Choose()
- feat: add IEnumerable<T>.Choose for Maybe
- chore: update dependencies
- BREAKING CHANGE: extend Option module for Maybe/FSharpOption interop
