### PR TITLE
fix: rename IDictionary.TryGet to TryGetValue

### DIFF
--- a/Base.Tests/Structures/MaybeExtensionTests.cs
+++ b/Base.Tests/Structures/MaybeExtensionTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using FruityFoundation.Base.Structures;
 using NUnit.Framework;
 
@@ -25,5 +27,73 @@ public class MaybeExtensionTests
 	{
 		Assert.IsNull(Maybe.Empty<int>().ToNullable());
 		Assert.IsNull(Maybe.Just(0, hasValue: _ => false).ToNullable());
+	}
+
+	[Test]
+	public void IDictionaryTests_TryGetValue_ReturnsMaybeWithValue_ForValidKey()
+	{
+		var dict = new Dictionary<string, int>
+		{
+			{ "one", 1 },
+			{ "two", 2 },
+			{ "three", 3 }
+		};
+
+		var result = dict.TryGetValue("one");
+
+		Assert.That(result, Is.InstanceOf<Maybe<int>>());
+		Assert.That(result.HasValue, Is.True);
+		Assert.That(result.Value, Is.EqualTo(1));
+	}
+
+	[Test]
+	public void IDictionaryTests_TryGetValue_ReturnsEmptyMaybe_ForInvalidKey()
+	{
+		var dict = new Dictionary<string, int>
+		{
+			{ "one", 1 },
+			{ "two", 2 },
+			{ "three", 3 }
+		};
+
+		var result = dict.TryGetValue("eight");
+
+		Assert.That(result, Is.InstanceOf<Maybe<int>>());
+		Assert.That(result.HasValue, Is.False);
+	}
+
+	[Test]
+	public void IReadOnlyDictionaryTests_TryGetValue_ReturnsMaybeWithValue_ForValidKey()
+	{
+		var baseDict = new Dictionary<string, int>
+		{
+			{ "one", 1 },
+			{ "two", 2 },
+			{ "three", 3 }
+		};
+		IReadOnlyDictionary<string, int> dict = new ReadOnlyDictionary<string, int>(baseDict);
+
+		var result = dict.TryGet("one");
+
+		Assert.That(result, Is.InstanceOf<Maybe<int>>());
+		Assert.That(result.HasValue, Is.True);
+		Assert.That(result.Value, Is.EqualTo(1));
+	}
+
+	[Test]
+	public void IIReadOnlyDictionaryTests_TryGetValue_ReturnsEmptyMaybe_ForInvalidKey()
+	{
+		var baseDict = new Dictionary<string, int>
+		{
+			{ "one", 1 },
+			{ "two", 2 },
+			{ "three", 3 }
+		};
+		IReadOnlyDictionary<string, int> dict = new ReadOnlyDictionary<string, int>(baseDict);
+
+		var result = dict.TryGet("eight");
+
+		Assert.That(result, Is.InstanceOf<Maybe<int>>());
+		Assert.That(result.HasValue, Is.False);
 	}
 }

--- a/Base/Structures/MaybeExtensions.cs
+++ b/Base/Structures/MaybeExtensions.cs
@@ -22,7 +22,7 @@ public static class MaybeExtensions
 		return Maybe.Empty<T>();
 	}
 
-	public static Maybe<TValue> TryGet<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key) =>
+	public static Maybe<TValue> TryGetValue<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key) =>
 		dict.TryGetValue(key, out var value) ? Maybe.Just(value) : Maybe.Empty<TValue>();
 
 	public static Maybe<TValue> TryGet<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dict, TKey key) =>


### PR DESCRIPTION
This resolves ambiguous invocation errors
